### PR TITLE
Fix warnings.

### DIFF
--- a/src/schism/Renderer/Texture.h
+++ b/src/schism/Renderer/Texture.h
@@ -22,7 +22,7 @@ namespace Schism::Renderer
 		GLenum GetFormat() const { return m_Format; }
 		int GetWidth() const { return m_Width; }
 		int GetHeight() const { return m_Height; }
-		const glm::vec2& GetSize() const { return { m_Width, m_Height }; }
+		const glm::vec2 GetSize() const { return { m_Width, m_Height }; }
 
 		bool operator==(Texture& other) const
 		{

--- a/src/schism/System/Log.h
+++ b/src/schism/System/Log.h
@@ -4,7 +4,7 @@
 
 namespace Schism
 {
-	constexpr char* LOG_FILENAME = "schism.log";
+	const std::string LOG_FILENAME = "schism.log";
 
 	class Log
 	{


### PR DESCRIPTION
 * ISO C++ does not allow C like `char*` for literals
 * returning a reference to a stack allocated struct may result in undefined behavior